### PR TITLE
fix bug that FreeCAD does not have a bundle identifier

### DIFF
--- a/conda/osx/create_bundle.sh
+++ b/conda/osx/create_bundle.sh
@@ -20,6 +20,8 @@ version_name=$(conda run -p APP/FreeCAD.app/Contents/Resources python get_freeca
 conda list -p APP/FreeCAD.app/Contents/Resources > APP/FreeCAD.app/Contents/packages.txt
 sed -i "1s/.*/\n\nLIST OF PACKAGES:/"  APP/FreeCAD.app/Contents/packages.txt
 
+# add a bundle Identifier
+/usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier 'org.freecadteam.freecad'" "APP/FreeCAD.app/Contents/Info.plist"
 
 # delete unnecessary stuff
 rm -rf APP/FreeCAD.app/Contents/Resources/include


### PR DESCRIPTION
all macOS apps are supposed to have a CFBundleIdentifier. native preferences and caching will be broken without it.