### PR TITLE
Also save commit hash and branch info to Version.h

### DIFF
--- a/make_version_file.py
+++ b/make_version_file.py
@@ -39,8 +39,8 @@ with open("src/Build/Version.h.cmake", "r") as f:
 	text = f.read()
 	text = text.replace("${PACKAGE_WCREF}", f"{rev_number} (Git)")
 	text = text.replace("${PACKAGE_WCDATE}", commit_date)
-	text.append('#define FCRepositoryHash   "%s"\n' % (commit_hash))
-        text.append('#define FCRepositoryBranch "%s"\n' % (branch_name))
+	text = text + '#define FCRepositoryHash   "%s"\n' % (commit_hash)
+	text = text + '#define FCRepositoryBranch "%s"\n' % (branch_name)
 	
 with open("src/Build/Version.h.cmake", "w") as f:
 	f.write(text)

--- a/make_version_file.py
+++ b/make_version_file.py
@@ -39,6 +39,8 @@ with open("src/Build/Version.h.cmake", "r") as f:
 	text = f.read()
 	text = text.replace("${PACKAGE_WCREF}", f"{rev_number} (Git)")
 	text = text.replace("${PACKAGE_WCDATE}", commit_date)
+	text.append('#define FCRepositoryHash   "%s"\n' % (commit_hash))
+        text.append('#define FCRepositoryBranch "%s"\n' % (branch_name))
 	
 with open("src/Build/Version.h.cmake", "w") as f:
 	f.write(text)


### PR DESCRIPTION
based on https://github.com/FreeCAD/FreeCAD/blob/10888e7aad50d9a8162f8f3df8dedbd83dca1db1/src/Tools/SubWCRev.py#L205

I have not tested this but it should give more complete version info

FYI here's the automatic Version.h when building freecad from a git repository:
```

// Version Number
#define FCVersionMajor "0"
#define FCVersionMinor "20"
#define FCVersionName  "Vulcan"
// test: $Format:Hash (%H), Date: %ci$
#define FCRevision      "28901 (Git)"      //Highest committed revision number
#define FCRevisionDate  "2022/05/17 14:43:53"     //Date of highest committed revision
#define FCRepositoryURL "/I/censored/the/path/FreeCAD master"      //Repository URL of the working copy

// Git relevant stuff
#define FCRepositoryHash   "a5ff51580400894977021fbdac674b771984c243"
#define FCRepositoryBranch "master"

```
and here what comes with the src package currently published in the weekly release page:
```

// Version Number
#define FCVersionMajor "${PACKAGE_VERSION_MAJOR}"
#define FCVersionMinor "${PACKAGE_VERSION_MINOR}"
#define FCVersionName  "${PACKAGE_VERSION_NAME}"
// test: $Format:Hash (%H), Date: %ci$
#define FCRevision      "28901 (Git)"      //Highest committed revision number
#define FCRevisionDate  "2022/05/17 16:43:53"     //Date of highest committed revision
#define FCRepositoryURL "${PACKAGE_WCURL}"      //Repository URL of the working copy

```