### PR TITLE
Rewrite make_version_file.py

### DIFF
--- a/make_version_file.py
+++ b/make_version_file.py
@@ -2,53 +2,40 @@
 
 # call this file from within the FreeCAD git repo
 # this script creates a file with the important version information
-
+import os
 import sys
 import subprocess
 
-# get number of commits:
-p1 = subprocess.Popen(["git", "rev-list", "HEAD", "--count"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-p2 = subprocess.Popen(["git", "branch"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-p3 = subprocess.Popen(["git", "log", "-1", "--format=%ci"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-p4 = subprocess.Popen(["git", "rev-parse", "--short", "HEAD"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+sys.path.append(f"{os.getcwd()}/src/Tools")
+import SubWCRev
 
-out1, err1 = p1.communicate()
-out2, err2 = p2.communicate()
-out3, err3 = p3.communicate()
-out4, err4 = p4.communicate()
+gitInfo = SubWCRev.GitControl()
+gitInfo.extractInfo("","")
+i = open("src/Build/Version.h.cmake")
+content = []
+for line in i.readlines():
+    line = line.replace("${PACKAGE_WCREF}",gitInfo.rev)
+    line = line.replace("${PACKAGE_WCDATE}",gitInfo.date)
+    line = line.replace("${PACKAGE_WCURL}",gitInfo.url)
+    content.append(line)
 
-rev_number = out1.decode()
-branch_name = out2.decode().split(" ")[-1]
-commit_date = out3.decode().replace("-", "/").split(" ")
-commit_date = commit_date[0] + " " + commit_date[1]
-commit_hash = out4.decode()
+content.append('// Git relevant stuff\n')
+content.append('#define FCRepositoryHash   "%s"\n' % (gitInfo.hash))
+content.append('#define FCRepositoryBranch "%s"\n' % (gitInfo.branch))
+o = open("src/Build/Version.h.cmake", "w")
+o.writelines(content)
 
-rev_number = rev_number.replace("\n", "")
-branch_name = branch_name.replace("\n", "")
-commit_date = commit_date.replace("\n", "")
-commit_hash = commit_hash.replace("\n", "")
+with open(os.sys.argv[1], "w") as f:
+	f.write(f"rev_number: {gitInfo.rev}\n")
+	f.write(f"branch_name: {gitInfo.branch}\n")
+	f.write(f"commit_date: {gitInfo.date}\n")
+	f.write(f"commit_hash: {gitInfo.hash}\n")
+	f.write(f"remote_url: {gitInfo.url}\n")
 
-with open(sys.argv[1], "w") as f:
-	f.write(f"rev_number: {rev_number}\n")
-	f.write(f"branch_name: {branch_name}\n")
-	f.write(f"commit_date: {commit_date}\n")
-	f.write(f"commit_hash: {commit_hash}\n")
-	
-# replace numbers in version.h.cmake file
-with open("src/Build/Version.h.cmake", "r") as f:
-	text = f.read()
-	text = text.replace("${PACKAGE_WCREF}", f"{rev_number} (Git)")
-	text = text.replace("${PACKAGE_WCDATE}", commit_date)
-	text = text + '#define FCRepositoryHash   "%s"\n' % (commit_hash)
-	text = text + '#define FCRepositoryBranch "%s"\n' % (branch_name)
-	
-with open("src/Build/Version.h.cmake", "w") as f:
-	f.write(text)
-
-p6 = subprocess.Popen(["git", "-c", "user.name='ghaction'", "-c", "user.email='gh@action.org'",
+p = subprocess.Popen(["git", "-c", "user.name='ghaction'", "-c", "user.email='gh@action.org'",
 		       "commit", "-a", "-m", "add git information"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
-out6, err6 = p6.communicate()
+out, err = p.communicate()
 		     		       
-print(out6.decode())
-print(err6.decode())
+print(out.decode())
+print(err.decode())


### PR DESCRIPTION
Reusing existing functionality from the FreeCAD source, this has the added benefit of including the repo url that enables the functionality of having a link to the commit in the about dialog. To take advantage of this in the conda builds #117 should be solved.