### PR TITLE
[fixes #103] set PATH_TO_FREECAD_LIBDIR env var

### DIFF
--- a/conda/linux/AppDir/AppRun
+++ b/conda/linux/AppDir/AppRun
@@ -3,6 +3,7 @@ HERE="$(dirname "$(readlink -f "${0}")")"
 export PREFIX=${HERE}/usr
 export LD_LIBRARY_PATH=${HERE}/usr/lib${LD_LIBRARY_PATH:+':'}$LD_LIBRARY_PATH
 export PYTHONHOME=${HERE}/usr
+export PATH_TO_FREECAD_LIBDIR=${HERE}/usr/lib
 # export QT_QPA_PLATFORM_PLUGIN_PATH=${HERE}/usr/plugins
 # export QT_XKB_CONFIG_ROOT=${HERE}/usr/lib
 export FONTCONFIG_FILE=/etc/fonts/fonts.conf


### PR DESCRIPTION
Allows to import freecad when running python console from appimage