### PR TITLE
fix windows assets upload

### DIFF
--- a/.github/workflows/freecad_bundle.yml
+++ b/.github/workflows/freecad_bundle.yml
@@ -150,7 +150,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: conda\win_${{ matrix.python }}\FreeCAD*
+          file: conda/win_${{ matrix.python }}/FreeCAD*
           tag: ${{ matrix.tag }}
           overwrite: true
           file_glob: true


### PR DESCRIPTION
https://github.com/isaacs/node-glob/issues/480

according to this we should also use forward slashes for the glob pattern even on windows