### PR TITLE
Specify fmt version for linux and macOS bundles

### DIFF
--- a/conda/linux/create_bundle.sh
+++ b/conda/linux/create_bundle.sh
@@ -11,7 +11,7 @@ mamba create \
   numpy matplotlib-base scipy sympy pandas six \
   pyyaml opencamlib pycollada ifcopenshell \
   appimage-updater-bridge lxml xlutils olefile requests \
-  blinker opencv qt.py nine docutils fmt \
+  blinker opencv qt.py nine docutils fmt=9.1.0 \
   --copy -c conda-forge/label/freecad_rc -c conda-forge -y
 
 

--- a/conda/osx/create_bundle.sh
+++ b/conda/osx/create_bundle.sh
@@ -11,7 +11,7 @@ mamba create \
     numpy matplotlib-base scipy sympy pandas six \
     pyyaml jinja2 opencamlib ifcopenshell \
     pycollada lxml xlutils olefile requests \
-    blinker opencv qt.py nine docutils fmt \
+    blinker opencv qt.py nine docutils fmt=9.1.0 \
     --copy -c conda-forge/label/freecad_rc -c conda-forge -y
 
 


### PR DESCRIPTION
Now that a 10.0 package is available it's picking that but freecad was built against 9.1.0, this is a workaround while https://github.com/conda-forge/freecad-feedstock/pull/91 is not merged yet