### PR TITLE
Set job after Merge Meeting to get the newest build

### DIFF
--- a/.github/workflows/freecad_bundle.yml
+++ b/.github/workflows/freecad_bundle.yml
@@ -1,7 +1,7 @@
 name: freecad_bundle
 on:
   schedule:
-   - cron: "0 12 * * 0,4"
+   - cron: "0 15 * * 0,4"
   push:
     branches:
       - "*"


### PR DESCRIPTION
Change the job for the official weekly builds to run after the Merge Meeting on Mondays