### PR TITLE
macOS: fix rpaths in macOS CI builds

### DIFF
--- a/conda/osx/create_bundle.sh
+++ b/conda/osx/create_bundle.sh
@@ -55,6 +55,10 @@ find . -name "*.pyc" -type f -delete
 # qtwebengine fix
 mv ./APP/FreeCAD.app/Contents/Resources/resources ./APP/FreeCAD.app/Contents/Resources/Resources
 
+# fix problematic rpaths for signing
+# see https://github.com/FreeCAD/FreeCAD/issues/10144#issuecomment-1836686775
+mamba run -p ${conda_env} python ../scripts/fix_rpaths.py ${conda_env}/lib
+
 # create the dmg
 hdiutil create -volname "${version_name}" -srcfolder ./APP -ov -format UDZO "${version_name}.dmg"
 

--- a/conda/scripts/fix_rpaths.py
+++ b/conda/scripts/fix_rpaths.py
@@ -1,0 +1,57 @@
+import os
+import subprocess
+import re
+import sys
+
+if len(sys.argv) < 1 or "-h" in sys.argv:
+    print("Usage: python fix_rpaths.py <scan_path> [-r]")
+    sys.exit(1)
+
+scan_path = os.path.abspath(os.path.expanduser(sys.argv[1]))
+recursive = "-r" in sys.argv
+
+print(f"Scanning dir: {scan_path}")
+
+def get_lc_paths(output):
+    if "is not an object file" in output:
+        return []
+
+    result = []
+    matches = re.finditer(r'cmd LC_RPATH', output)
+    for match in matches:
+        pos = match.start(0)
+
+        path_match = re.search(r'path (.*) \(offset.+?\)', output[pos:])
+        result.append(path_match.group(1))
+
+    return result
+
+def remove_rpath(file_path, rpath):
+    subprocess.run(['install_name_tool', '-delete_rpath', rpath, file_path])
+    print(f'\nRemoved rpath {rpath} from {file_path}')
+
+def scan_directory(directory, recursive=False):
+    for filename in os.listdir(directory):
+        full_path = os.path.join(directory, filename)
+        if recursive and os.path.isdir(full_path):
+            scan_directory(full_path, recursive)
+            continue
+        elif not os.path.isfile(full_path) or os.path.islink(full_path):
+            continue
+
+        try:
+            output = subprocess.check_output(['otool', '-l', full_path], text=True)
+            lc_paths = get_lc_paths(output)
+        except:
+            continue
+
+        # if any(os.path.isabs(path) for path in lc_paths):
+        #     print(full_path, lc_paths)
+
+        file_dir = os.path.dirname(full_path)
+        for rpath in lc_paths:
+            if os.path.isabs(rpath) and os.path.samefile(file_dir, rpath):
+                remove_rpath(full_path, rpath)
+
+scan_directory(scan_path, recursive)
+print("Done removing problematic rpaths.")

--- a/conda/scripts/fix_rpaths.py
+++ b/conda/scripts/fix_rpaths.py
@@ -28,6 +28,7 @@ def get_lc_paths(output):
 
 def remove_rpath(file_path, rpath):
     subprocess.run(['install_name_tool', '-delete_rpath', rpath, file_path])
+    subprocess.run(['codesign', '--force', '--sign', '-', file_path])
     print(f'\nRemoved rpath {rpath} from {file_path}')
 
 def scan_directory(directory, recursive=False):


### PR DESCRIPTION
Changes on top of ccef8eb4083ae038aa86ea1001de7ee136da1350 fixes signatures for libraries modified by `install_name_tool`

Additional changes according to findings in https://github.com/FreeCAD/FreeCAD/issues/10144#issuecomment-1847657394

I ran the `create_bundle.sh` to build new FreeCAD.app bundle. The bundle does not contain rpaths with absolute paths and the app does not crash when launched.

cc: @adrianinsaval
