### PR TITLE
macOS: Add symlink to /Applications and use bigger icons

### DIFF
--- a/conda/osx/create_bundle.sh
+++ b/conda/osx/create_bundle.sh
@@ -58,7 +58,8 @@ find . -name "*.pyc" -type f -delete
 mamba run -p ${conda_env} python ../scripts/fix_macos_lib_paths.py ${conda_env}/lib
 
 # create the dmg
-hdiutil create -volname "${version_name}" -srcfolder ./APP -ov -format UDZO "${version_name}.dmg"
+pip3 install "dmgbuild[badge_icons]>=1.6.0,<1.7.0"
+dmgbuild -s dmg_settings.py "FreeCAD" "${version_name}.dmg"
 
 # create hash
 shasum -a 256 ${version_name}.dmg > ${version_name}.dmg-SHA256.txt

--- a/conda/osx/dmg_settings.py
+++ b/conda/osx/dmg_settings.py
@@ -1,0 +1,6 @@
+files = ["./APP/FreeCAD.app"]
+symlinks = {"Applications": "/Applications"}
+badge_icon = "./APP/FreeCAD.app/Contents/Resources/freecad.icns"
+window_rect = ((200, 200), (600, 400))
+icon_locations = {"FreeCAD.app": (180, 150), "Applications": (420, 150)}
+size = "3g"


### PR DESCRIPTION
This uses `dmgbuild` to create a DMG with bigger icons and a symlink to `/Applications`. As it does not yet contain a background image or color, it adapts to dark and light mode settings:

<img width="712" alt="Screenshot 2024-06-14 at 10 16 52" src="https://github.com/FreeCAD/FreeCAD-Bundle/assets/814785/b3fafeb6-32c6-4fc3-835f-4cec7717f0ee">

<img width="712" alt="Screenshot 2024-06-14 at 10 17 10" src="https://github.com/FreeCAD/FreeCAD-Bundle/assets/814785/c8b42cda-85d8-4b58-bbe5-56eb9c5c1ee2">


Partially addresses #242.