### PR TITLE
Remove erroneous quotes from sed command line.

### DIFF
--- a/conda/osx/create_bundle.sh
+++ b/conda/osx/create_bundle.sh
@@ -23,7 +23,7 @@ echo -e "version_name:  ${version_name}"
 echo -e "################"
 
 mamba list -p ${conda_env} > APP/FreeCAD.app/Contents/packages.txt
-sed -i "" "1s/.*/\nLIST OF PACKAGES:/"  APP/FreeCAD.app/Contents/packages.txt
+sed -i "1s/.*/\nLIST OF PACKAGES:/"  APP/FreeCAD.app/Contents/packages.txt
 
 # copy the QuickLook plugin into its final location
 mv ${conda_env}/Library ${conda_env}/../Library


### PR DESCRIPTION
As noted by https://github.com/FreeCAD/FreeCAD/pull/15366#discussion_r1675799471, an extra set of quotation marks were included in the `osx` variant of this script.