### PR TITLE
README: Reorientation toward curbing incorrect FreeCAD main bugreports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# FreeCAD-Bundle 
-*(Formerly FreeCAD-AppImage)*
+# FreeCAD-Bundle[^1] 
 
-Weekly generated FreeCAD development builds for testing the latest features/bug fixes
+## ATTENTION: THIS IS *NOT* THE FREECAD BUGTRACKER[^2]
 
-Download bundles from [releases/tag/weekly-builds](https://github.com/FreeCAD/FreeCAD-Bundle/releases/tag/weekly-builds)
+This is strictly an OS/Distro related packaging repository. Weekly generated FreeCAD development builds for testing the latest features/bug fixes. Please only open packaging or building FreeCAD related issues here.
 
+Download weekly bundles from [releases/tag/weekly-builds](https://github.com/FreeCAD/FreeCAD-Bundle/releases/tag/weekly-builds).
 
+[^1]: This repository was formerly named *FreeCAD-AppImage*
+[^2]: https://github.com/FreeCAD/FreeCAD/issues


### PR DESCRIPTION
Part of campaign (#299) to stop errant bug reports in the wrong repo.

Preview: https://github.com/FreeCAD/FreeCAD-Bundle/blob/README/README.md