### PR TITLE
Add bug report issue template (#299)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Bugs regarding **PACKAGING** related issues
+title: "[Problem]"
+labels: ''
+assignees: ''
+
+---
+
+### Attention: if you've found a bug related to FreeCAD itself, post it to the main bugtracker https://github.com/FreeCAD/FreeCAD/issues
+
+**Describe the bug**
+A clear and concise description of what the packaging related bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Added another level of abstraction against incorrect filing of bugs.  
Closes #299
Preview: https://github.com/FreeCAD/FreeCAD-Bundle/blob/issue-template/.github/ISSUE_TEMPLATE/bug-report.md