### PR TITLE
macOS: Use system theme for title bar.

### DIFF
--- a/conda/osx/Info.plist.template
+++ b/conda/osx/Info.plist.template
@@ -34,6 +34,8 @@
 	<string>NSApplication</string>
 	<key>NSHighResolutionCapable</key>
 	<string>True</string>
+	<key>NSRequiresAquaSystemAppearance</key>
+	<string>False</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Some users have been experiencing FreeCAD's title bar being in the light theme instead of adopting system theme conventions.  This change the `Info.plist` is intended to force using system theme by default.

https://forum.freecad.org/viewtopic.php?t=56992
