### PR TITLE
Fix Qt6 migration

### DIFF
--- a/conda/linux/create_bundle.sh
+++ b/conda/linux/create_bundle.sh
@@ -60,16 +60,21 @@ cp ${conda_env}/bin_tmp/freecadcmd ${conda_env}/bin/
 cp ${conda_env}/bin_tmp/ccx ${conda_env}/bin/
 cp ${conda_env}/bin_tmp/python ${conda_env}/bin/
 cp ${conda_env}/bin_tmp/pip ${conda_env}/bin/
-cp ${conda_env}/bin_tmp/pyside2-rcc ${conda_env}/bin/
+if [ -f ${conda_env}/bin_tmp/pyside6-rcc ]
+then
+    cp ${conda_env}/bin_tmp/pyside6-rcc ${conda_env}/bin/
+else
+    cp ${conda_env}/bin_tmp/pyside2-rcc ${conda_env}/bin/
+fi
 cp ${conda_env}/bin_tmp/gmsh ${conda_env}/bin/
 cp ${conda_env}/bin_tmp/dot ${conda_env}/bin/
 cp ${conda_env}/bin_tmp/unflatten ${conda_env}/bin/
 sed -i '1s|.*|#!/usr/bin/env python|' ${conda_env}/bin/pip
 rm -rf ${conda_env}/bin_tmp
 
-echo -e "\nCopy qt.conf"
-cp qt.conf ${conda_env}/bin/
-cp qt.conf ${conda_env}/libexec/
+echo -e "\nCopy qt6.conf"
+cp qt6.conf ${conda_env}/bin/
+cp qt6.conf ${conda_env}/libexec/
 
 echo -e "\nCopying Icon and Desktop file"
 cp ${conda_env}/share/applications/org.freecad.FreeCAD.desktop AppDir/

--- a/conda/linux/qt.conf
+++ b/conda/linux/qt.conf
@@ -1,2 +1,0 @@
-[Paths]
-Prefix = ./../

--- a/conda/linux/qt6.conf
+++ b/conda/linux/qt6.conf
@@ -1,0 +1,4 @@
+[Paths]
+Prefix    = ..
+Libraries = lib
+Plugins   = lib/qt6/plugins

--- a/conda/osx/create_bundle.sh
+++ b/conda/osx/create_bundle.sh
@@ -46,7 +46,12 @@ cp ${conda_env}/bin_tmp/freecadcmd ${conda_env}/bin
 cp ${conda_env}/bin_tmp/ccx ${conda_env}/bin/
 cp ${conda_env}/bin_tmp/python ${conda_env}/bin/
 cp ${conda_env}/bin_tmp/pip ${conda_env}/bin/
-cp ${conda_env}/bin_tmp/pyside2-rcc ${conda_env}/bin/
+if [ -f ${conda_env}/bin_tmp/pyside6-rcc ]
+then
+    cp ${conda_env}/bin_tmp/pyside6-rcc ${conda_env}/bin/
+else
+    cp ${conda_env}/bin_tmp/pyside2-rcc ${conda_env}/bin/
+fi
 cp ${conda_env}/bin_tmp/gmsh ${conda_env}/bin/
 cp ${conda_env}/bin_tmp/dot ${conda_env}/bin/
 cp ${conda_env}/bin_tmp/unflatten ${conda_env}/bin/
@@ -56,9 +61,9 @@ rm -rf ${conda_env}/bin_tmp
 #copy resources
 cp resources/* ${conda_env}
 
-#copy qt.conf
-cp qt.conf ${conda_env}/bin/
-cp qt.conf ${conda_env}/libexec/
+# Copy qt6.conf
+cp qt6.conf ${conda_env}/bin/
+cp qt6.conf ${conda_env}/libexec/
 
 # Remove __pycache__ folders and .pyc files
 find . -path "*/__pycache__/*" -delete

--- a/conda/osx/qt.conf
+++ b/conda/osx/qt.conf
@@ -1,2 +1,0 @@
-[Paths]
-Prefix = ./../

--- a/conda/osx/qt6.conf
+++ b/conda/osx/qt6.conf
@@ -1,0 +1,4 @@
+[Paths]
+Prefix    = ..
+Libraries = lib
+Plugins   = lib/qt6/plugins

--- a/conda/osx/resources/qt.conf
+++ b/conda/osx/resources/qt.conf
@@ -1,2 +1,0 @@
-[Paths]
-Plugins=lib/qtplugins

--- a/conda/osx/resources/qt6.conf
+++ b/conda/osx/resources/qt6.conf
@@ -1,0 +1,4 @@
+[Paths]
+Prefix    = ../..
+Libraries = lib
+Plugins   = lib/qt6/plugins

--- a/conda/win/create_bundle.bat
+++ b/conda/win/create_bundle.bat
@@ -61,8 +61,8 @@ REM Copy Conda's QT5/plugins to FreeCAD/bin
 robocopy %conda_env%\Library\plugins %copy_dir%\bin\ /S /MT:%NUMBER_OF_PROCESSORS% > nul
 robocopy %conda_env%\Library\resources %copy_dir%\resources /MT:%NUMBER_OF_PROCESSORS% > nul
 robocopy %conda_env%\Library\translations %copy_dir%\translations /MT:%NUMBER_OF_PROCESSORS% > nul
-echo [Paths] > %copy_dir%\bin\qt.conf
-echo Prefix =.. >> "%copy_dir%\bin\qt.conf"
+echo [Paths] > %copy_dir%\bin\qt6.conf
+echo Prefix =.. >> "%copy_dir%\bin\qt6.conf"
 REM get all the dependency .dlls
 robocopy %conda_env%\Library\bin *.dll %copy_dir%\bin /XF *.pdb /XF api*.* /MT:%NUMBER_OF_PROCESSORS% > nul
 REM Copy FreeCAD build


### PR DESCRIPTION
This is a PR to solve issue https://github.com/FreeCAD/FreeCAD-Bundle/issues/387 ( AppImage was not starting due to bad Qt6 configuration )

Thanks to @VM4Dim for providing the fix

More info in FreeCAD forum on thread: [\[QT6 migration\] Weekly bundle do not start (core dumped)](https://forum.freecad.org/viewtopic.php?p=817872#p817872)