### PR TITLE
Pin numpy to 1.26.x

### DIFF
--- a/conda/linux/create_bundle.sh
+++ b/conda/linux/create_bundle.sh
@@ -24,7 +24,7 @@ mamba create --copy -p ${conda_env} \
   lxml \
   matplotlib-base \
   nine \
-  numpy \
+  numpy=1.26 \
   occt \
   olefile \
   opencamlib \

--- a/conda/osx/create_bundle.sh
+++ b/conda/osx/create_bundle.sh
@@ -22,7 +22,7 @@ mamba create --copy -p ${conda_env} \
   lxml \
   matplotlib-base \
   nine \
-  numpy \
+  numpy=1.26 \
   occt \
   olefile \
   opencamlib \

--- a/conda/win/create_bundle.bat
+++ b/conda/win/create_bundle.bat
@@ -14,7 +14,7 @@ call mamba create --copy -y -p %conda_env% ^
   docutils ^
   gmsh ^
   ifcopenshell ^
-  lark ^ ^
+  lark ^
   lxml ^
   matplotlib-base ^
   nine ^
@@ -33,7 +33,7 @@ call mamba create --copy -y -p %conda_env% ^
   vtk ^
   xlutils ^
   -y
-  
+
 %conda_env%\python ..\scripts\get_freecad_version.py
 set /p freecad_version_name= <bundle_name.txt
 

--- a/conda/win/create_bundle.bat
+++ b/conda/win/create_bundle.bat
@@ -18,7 +18,7 @@ call mamba create --copy -y -p %conda_env% ^
   lxml ^
   matplotlib-base ^
   nine ^
-  numpy ^
+  numpy=1.26 ^
   occt ^
   olefile ^
   opencamlib ^


### PR DESCRIPTION
Currently `numpy>=2` have issues when installed from conda-forge.  Furthermore, VFX Platform currently standardizes on `numpy==1.26`.

This PR pins numpy to 1.26 which should resolve the current issues plaguing recent releases and ensuring compatibility with other VFX Platform compliant systems.